### PR TITLE
Updated ci script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,6 @@ jobs:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,7 @@ jobs:
         run: go test ./vector2/ ./vector3/ -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload Coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.16'
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Run Test and Coverage
         run: go test ./vector2/ ./vector3/ -race -coverprofile=coverage.txt -covermode=atomic


### PR DESCRIPTION
Thanks for a nice lib! I'm forking it because I prefer not using pointers for my vectors. So I updated the CI script before going my own way:
- checkout v4 (using an up-to-date node version)
- setup-go v5: reads go version from go.mod
- codecov-action: the bash version you use now is no longer being updated

I couldn't get the tokenless codecov working for my fork, so I added the token to my repo secrets. You might need to do that also, if you haven't already.